### PR TITLE
Fixed maintenance page for newly added tenants

### DIFF
--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -206,12 +206,21 @@ router.get('/tenant/unit/:id', withAuth, async (req, res) => {
       }, {
         model: Landlord,
         attributes: { exclude: ["password"] }
-      }, {
-        model: Maintenance, where: { tenant_id: req.session.tenant_id }
       }],
     })
+    
     const unit = unitById.get({ plain: true })
-    console.log(unit)
+    console.log('*********', unit)
+    
+    // const maintenance = await Maintenance.findAll({
+    //   where: { tenant_id: req.session.tenant_id }
+    // })
+
+    // const userMaintenance = maintenance.get({ plain: true })
+    // console.log('*********', userMaintenance)
+    //   // {
+    //   //   model: Maintenance, where: {  }
+    //   // }
     res.render('unit-tenant', { unit, logged_in: true })
   } catch (err) {
     res.status(500).json(err)
@@ -227,9 +236,13 @@ router.get('/tenant/maintenance/:id', withAuth, async (req, res) => {
       }]
     })
 
-    const unit = unitById.get({ plain: true })
-    console.log(unit)
-    res.render('maintenance-tenant', { unit, logged_in: true })
+    if (unitById) {
+      const unit = unitById.get({ plain: true })
+      console.log(unit)
+      res.render('maintenance-tenant', { unit, logged_in: true })
+    } else {
+      res.render('maintenance-tenant', { logged_in: true })
+    }
   } catch (err) {
     res.status(500).json(err)
   }

--- a/views/landlord-posts.handlebars
+++ b/views/landlord-posts.handlebars
@@ -6,7 +6,7 @@
 {{#each convo as |conv| }}
 
 <div class="columns m-5 is-flex is-flex-wrap-wrap is-justify-content-space-around">
-    <div class="ticket box column is-two-fifths has-text-black">
+    <div class="ticket box column is-three-fifths has-text-black">
         <div class="m-2"><strong>{{conv.content}}</strong> - (between {{conv.landlord.name}} and {{conv.tenant.name}},
             {{format_date conv.date_submitted}})</div><br>
         {{#if conv.comments}}

--- a/views/maintenance-tenant.handlebars
+++ b/views/maintenance-tenant.handlebars
@@ -1,7 +1,11 @@
 <div class="background-PMU">
     <h1 class="is-size-2 has-text-centered has-text-black p-4">Your Maintenance Tickets</h1>
 
+    {{#if unit.maintenances.length}}
     <div class="card-body is-flex is-flex-direction-column">
         {{> maintenance }}
     </div>
-</div>
+    {{else}}
+    <h2 class="is-size-4 has-text-gray has-text-centered">~You have no maintenance tickets~</h2>
+    {{/if}}
+</div> 


### PR DESCRIPTION
Found an error when entering the account for a new tenant, the maintenance would give 500 error when the maintenance model doesn't have data with this tenant_id. Fixed it. Also removed maintenance history from /tenant/unit. I think it makes more sense that way.